### PR TITLE
Fix bug on rom update

### DIFF
--- a/rnodeconf/rnodeconf.py
+++ b/rnodeconf/rnodeconf.py
@@ -870,7 +870,7 @@ def main():
                         model = ROM.MODEL_A4
                     if args.model == "a9":
                         model = ROM.MODEL_A9
-                    if args.hwrev > 0 and args.hwrev < 256:
+                    if args.hwrev != None and (args.hwrev > 0 and args.hwrev < 256):
                         hwrev = chr(args.hwrev)
 
                     if serialno > 0 and model != None and hwrev != None:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="rnodeconf",
-    version="0.9.9",
+    version="0.9.10",
     author="Mark Qvist",
     author_email="mark@unsigned.io",
     description="Configuration Utility for RNode hardware",


### PR DESCRIPTION
This fixes:

Traceback (most recent call last):
  File "./rnodeconfig", line 1055, in <module>
    main()
  File "./rnodeconfig", line 873, in main
    if args.hwrev > 0 and args.hwrev < 256:
TypeError: '>' not supported between instances of 'NoneType' and 'int'