### PR TITLE
Correct public exponent

### DIFF
--- a/rnodeconf/rnodeconf.py
+++ b/rnodeconf/rnodeconf.py
@@ -709,7 +709,7 @@ def main():
         if args.key:
             RNS.log("Generating a new signing key...")
             private_key = rsa.generate_private_key(
-                public_exponent=65337,
+                public_exponent=65537,
                 key_size=1024,
                 backend=default_backend()
             )


### PR DESCRIPTION
I received the following error when attempting to generate a new signing key, which seemed to indicate `65537` is the correct value rather than `65337`:

```
# rnodeconf -k
[2021-12-14 00:42:21] Generating a new signing key...
Traceback (most recent call last):
  File "/usr/bin/rnodeconf", line 8, in <module>
    sys.exit(main())
  File "/usr/lib/python3.9/site-packages/rnodeconf/rnodeconf.py", line 711, in main
    private_key = rsa.generate_private_key(
  File "/usr/lib/python3.9/site-packages/cryptography/hazmat/primitives/asymmetric/rsa.py", line 127, in generate_private_key
    _verify_rsa_parameters(public_exponent, key_size)
  File "/usr/lib/python3.9/site-packages/cryptography/hazmat/primitives/asymmetric/rsa.py", line 133, in _verify_rsa_parameters
    raise ValueError(
ValueError: public_exponent must be either 3 (for legacy compatibility) or 65537. Almost everyone should choose 65537 here!
```

Tested OK on a manually patched copy.