### PR TITLE
Sleep a little longer when probing

### DIFF
--- a/rnodeconf/rnodeconf.py
+++ b/rnodeconf/rnodeconf.py
@@ -608,7 +608,7 @@ class RNode():
     def device_probe(self):
         sleep(2.5)
         self.detect()
-        sleep(0.1)
+        sleep(0.5)
         if self.detected == True:
             RNS.log("Device connected")
             RNS.log("Firmware version: "+self.version)


### PR DESCRIPTION
While setting up _RNode_ on some Arduino Mega 2560s today, I was only managing about a 1 out of 10 success rate with having `rnodeconf` detect them. Increasing the `sleep` here resolved the issue.